### PR TITLE
making tuto files working for terraform v0.15 (1-dev_vpc)

### DIFF
--- a/1-dev-vpc/main.tf
+++ b/1-dev-vpc/main.tf
@@ -28,8 +28,19 @@ variable "database_subnets" {
 # PROVIDERS
 #############################################################################
 
+# for terraform v0.13 and later
+# specify version in this block
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# configure your provider in this block
 provider "aws" {
-  version = "~> 2.0"
   region  = var.region
 }
 
@@ -45,7 +56,7 @@ data "aws_availability_zones" "azs" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.33.0"
+  version = ">= 2.58.0"
 
   name = "dev-vpc"
   cidr = var.vpc_cidr_range


### PR DESCRIPTION
hello! im working thru your tutorials on Pluralsight.  I learn a lot thanks!

but __tuto files doesnt work with current terraform v0.15__

my fixes make it work

I suggest minimal changes to `main.tf`

1. bump required VPC module required to at least `2.58.0` (in order to make it work under Terraform v0.15)
2. adopt Terraform suggested provider blocks 

- Required_providers : where you can specifiy version
- Providers : where you dont specify version anymore (because deprecated)

[https://registry.terraform.io/providers/hashicorp/aws/latest/docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)